### PR TITLE
use email if real_name is empty

### DIFF
--- a/triagebot.py
+++ b/triagebot.py
@@ -185,6 +185,8 @@ class Bug:
         for field in fields:
             setattr(self, field, getattr(details, field))
         self.assigned_to_name = details.assigned_to_detail['real_name']
+        if not self.assigned_to_name:
+            self.assigned_to_name = details.assigned_to_detail['email']
 
     def __str__(self):
         return f'[{self.bz}] {self.summary}'


### PR DESCRIPTION
If the 'real_name' field is empty/blank, messages to Slack look like:

```
Resolved by @micah. Bug now POST, assigned to **. Unresolve with @rhcos-triage-bot unresolve
```

This will test if the `real_name` string is empty and use the `email`
value if so.